### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :not_sign_in, except: [:index]
   def index
+    @item = Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :not_sign_in, except: [:index]
   def index
-    @item = Item.all
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,10 +14,10 @@ class Item < ApplicationRecord
     validates :product_name, length: { maximum: 40 }
     validates :price, length: { minimum: 3, maximum: 7 }, numericality: { only_integer: true, greater_than: 300, less_than: 10_000_000 }
     validates :product_description, length: { maximum: 40 }
-    validates :category_id, numericality: { other_than: 0, message: "can't be blank" } 
-    validates :product_status_id, numericality: { other_than: 0,message: "can't be blank" } 
-    validates :delivery_fee_id, numericality: { other_than: 0, message: "can't be blank" } 
-    validates :shipping_area_id, numericality: { other_than: 0, message: "can't be blank" } 
-    validates :shipping_data_id, numericality: { other_than: 0, message: "can't be blank" } 
+    validates :category_id, numericality: { other_than: 0, message: "can't be blank" }
+    validates :product_status_id, numericality: { other_than: 0, message: "can't be blank" }
+    validates :delivery_fee_id, numericality: { other_than: 0, message: "can't be blank" }
+    validates :shipping_area_id, numericality: { other_than: 0, message: "can't be blank" }
+    validates :shipping_data_id, numericality: { other_than: 0, message: "can't be blank" }
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,12 +125,11 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% @item.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to items_path do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outの表示 %>
           <div class='sold-out'>
@@ -141,10 +140,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.product_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
+            <span><%= item.price %>円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,6 +152,7 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,7 +125,7 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-    <% @item.each do |item| %>
+    <% @items.each do |item| %>
       <li class='list'>
         <%= link_to items_path do %>
         <div class='item-img-content'>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -41,19 +41,19 @@ RSpec.describe Item, type: :model do
       it '販売価格が全角では登録できない' do
         @item.price = 'あ００あ'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
 
       it '販売価格が¥300未満だと登録できない' do
         @item.price = '299'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be greater than 300")
+        expect(@item.errors.full_messages).to include('Price must be greater than 300')
       end
 
       it '販売価格が¥10000000以上だと登録できない' do
         @item.price = '10000000'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be less than 10000000")
+        expect(@item.errors.full_messages).to include('Price must be less than 10000000')
       end
 
       it 'カテゴリーが未選択では登録できない' do


### PR DESCRIPTION
#What 
商品一覧表示機能作成

#Why
商品一覧表示機能を実装するため

※売却済みの商品に「sold out」の文字が表示されるようにする記述に関しましては、商品購入機能実装時に行いたいと思います。